### PR TITLE
Fix edge scroll hang when the cursor leaves the window on Wayland

### DIFF
--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -311,12 +311,29 @@ bool do_scroll(double x, double y) {
     return fScrolled;
 }
 
+// On Wayland/XWayland, GetCursorPos FREEZES at the last position the pointer had over the
+// game's surface once the cursor moves onto another monitor or a native Wayland window:
+// Wayland has no API to query the global pointer position, so a client only learns where the
+// pointer is while it is over its own window. check_scroll() below relied on GetCursorPos
+// changing to detect the cursor leaving the edge zone; under Wayland that never happens, so
+// the loop spins forever and the game appears frozen (scrolling) while the real cursor moves
+// freely. s_pointer_in_window is the reliable signal -- driven by WM_MOUSELEAVE / WM_MOUSEMOVE
+// (armed via TrackMouseEvent in ModWinProc), which Wine still delivers correctly off-surface.
+static bool s_pointer_in_window = true;
+
 void check_scroll() {
     POINT p;
     if (CState.Scrolling || (!GetCursorPos(&p) && !(CState.ScrollDragging && CState.RightButtonDown))) {
         return;
     }
     CState.Scrolling = true;
+    // If the pointer has already left the game window, do not edge-scroll: GetCursorPos would
+    // return a stale on-edge position under Wayland and scroll the map forever. Drag-scroll
+    // (held right button) is exempt -- it is driven by button state and relative motion.
+    if (!s_pointer_in_window && !CState.RightButtonDown) {
+        CState.Scrolling = false;
+        return;
+    }
     int w = CState.ScreenSize.x;
     int h = CState.ScreenSize.y;
     static ULONGLONG ullDeactiveTimer = 0;
@@ -337,6 +354,8 @@ void check_scroll() {
     CState.ScrollOffsetY = MapWin->iMapPixelTop;
     ullNewTickCount = get_ms_count();
     ullOldTickCount = ullNewTickCount;
+    // Timestamp the start of this scrolling burst so the loop can bound itself (below).
+    ULONGLONG ullLoopStart = ullNewTickCount;
 //    debug("scroll_check %d %d %d\n", CState.Scrolling, (int)CState.ScrollDragPos.x, (int)CState.ScrollDragPos.y);
     do {
         double dTPS = -1;
@@ -396,6 +415,14 @@ void check_scroll() {
                 (int)p.x, (int)p.y, CState.ScrollOffsetX, CState.ScrollOffsetY, dx, dy, dTPS);
         }
 
+        // Bound this scrolling burst so it yields to the message pump, which is what processes
+        // WM_MOUSELEAVE and updates s_pointer_in_window. Without this, a frozen GetCursorPos
+        // (cursor left the window on Wayland) keeps fScrolled true and the loop never returns --
+        // the documented hang. mod_blink_timer re-drives check_scroll for continuous scrolling
+        // while the cursor is genuinely still held at the edge. Drag-scroll is exempt.
+        if (!CState.ScrollDragging && ullNewTickCount - ullLoopStart > 100) {
+            break;
+        }
     } while (fScrolled && (GetCursorPos(&p) || (CState.ScrollDragging && CState.RightButtonDown)));
 
     if (fScrolledAtAll) {
@@ -561,6 +588,18 @@ LRESULT WINAPI ModWinProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
     static int delta_accum = 0;
     POINT p;
     MAP* sq;
+
+    // Track whether the OS pointer is inside the game window. WM_MOUSELEAVE (armed via
+    // TrackMouseEvent on each move) is the reliable "cursor left" signal under Wayland, where
+    // GetCursorPos cannot report it (see s_pointer_in_window above). This only sets the flag --
+    // it does not consume the message, so all handling below is unaffected.
+    if (msg == WM_MOUSEMOVE) {
+        s_pointer_in_window = true;
+        TRACKMOUSEEVENT tme = { sizeof(TRACKMOUSEEVENT), TME_LEAVE, hwnd, 0 };
+        TrackMouseEvent(&tme);
+    } else if (msg == WM_MOUSELEAVE) {
+        s_pointer_in_window = false;
+    }
 
     if (msg == WM_ACTIVATEAPP && conf.auto_minimise && !conf.reduced_mode) {
         if (!LOWORD(wParam)) {


### PR DESCRIPTION
## What?

Fixes the edge-scroll hang under Wayland/XWayland: pushing the cursor to a screen edge to scroll the map could lock the game into scrolling forever, ignoring every other input, until you clicked back inside the window.

## Why?

On Wayland this bites hard. When you edge-scroll and the cursor slides off the game's window — onto another monitor or a native Wayland window — the map keeps scrolling on its own and the game stops responding to anything else. The cursor itself is visibly free, moving around the desktop; it's only the game that's stuck, still reading a mouse position that no longer means anything. On a multi-monitor setup you hit it constantly, because the edge you're scrolling toward is usually the edge you're about to cross. It's the same hang the PRACX author described back in 2016 in DrazharLn/pracx#3 — on X it was a soft UI stall, but under Wayland it's a full freeze.

## How?

The old edge-scroll loop kept going as long as `GetCursorPos` still reported the cursor inside the edge zone. On Wayland `GetCursorPos` freezes at the last position the cursor had over the window once it leaves — Wayland has no way to query the global pointer position, so a client only knows where the pointer is while it's over its own surface — so that exit condition never clears. I switched the "is the cursor still here?" test from polling that frozen position to a `WM_MOUSELEAVE` flag (armed with `TrackMouseEvent`), which Wine still delivers correctly off-surface, and capped each scroll burst so the loop always yields back to the message pump that processes it.

## Testing?

- Built the 32-bit `thinker.dll` with the MinGW cross-toolchain on Fedora 44, running the GOG copy of SMACX under Wine-GE (GE-Proton8-26) on KDE Plasma 6 / Wayland, NVIDIA.
- Before: edge-scroll toward the other monitor → permanent scroll-lock, no input accepted until I clicked back in the window. After: the map stops the instant the cursor leaves the window, and every other input keeps working.
- Ran a full session — edge-scroll in all four directions across both monitors, plus right-button drag-scroll (which this doesn't touch) — no hangs.

## Anything Else?

I used Claude Code (Opus 4.8) to help track this down and write the fix — reading the Wine and Thinker source to pin the root cause, then confirming `WM_MOUSELEAVE` actually fires off-surface on this setup before building anything. Happy to adjust if you'd rather the leave-detection or the burst cap were done differently.
